### PR TITLE
Updated asgrief version from 3.2.7 to 3.2.3 to fix bug with travis

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-asgiref==3.2.7
+asgiref==3.2.3
 coverage==5.1
 dj-database-url==0.5.0
 Django==1.11.29


### PR DESCRIPTION
Changed asgrief version as the 3.2.7 was raising error with Travis as not supported version